### PR TITLE
Transcribe py bugfixes

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -51,16 +51,16 @@ class AudioTextDataset(torch.utils.data.Dataset):
 		self.audio_backend = audio_backend
 		self.speakers = speakers
 
+		maybe_gzopen = lambda data_path: gzip.open(data_path, 'rt') if data_path.endswith('.gz') else open(data_path)
 		duration = lambda example: sum(map(transcripts.compute_duration, example))
 		data_paths = data_paths if isinstance(data_paths, list) else [data_paths]
 
 		def read_transcript(data_path):
 			assert os.path.exists(data_path)
-			if data_path.endswith('.json.gz'):
-				return json.load(gzip.open(data_path, 'rt'))
-			transcript_path = data_path if data_path.endswith('.json') else data_path + '.json'
-			if os.path.exists(transcript_path):
-				return json.load(open(data_path))
+			if data_path.endswith('.json') or data_path.endswith('.json.gz'):
+				return json.load(maybe_gzopen(data_path))
+			if os.path.exists(data_path + '.json'):
+				return json.load(open(data_path + '.json'))
 			return [dict(audio_path = data_path)]
 
 		self.examples = [

--- a/datasets.py
+++ b/datasets.py
@@ -55,7 +55,8 @@ class AudioTextDataset(torch.utils.data.Dataset):
 		data_paths = data_paths if isinstance(data_paths, list) else [data_paths]
 
 		def read_transcript(data_path):
-			if data_path.endswith('.json.gz') and os.path.exists(data_path):
+			assert os.path.exists(data_path)
+			if data_path.endswith('.json.gz'):
 				return json.load(gzip.open(data_path, 'rt'))
 			transcript_path = data_path if data_path.endswith('.json') else data_path + '.json'
 			if os.path.exists(transcript_path):

--- a/datasets.py
+++ b/datasets.py
@@ -51,14 +51,16 @@ class AudioTextDataset(torch.utils.data.Dataset):
 		self.audio_backend = audio_backend
 		self.speakers = speakers
 
-		maybegzopen = lambda data_path: gzip.open(data_path, 'rt') if data_path.endswith('.gz') else open(data_path)
 		duration = lambda example: sum(map(transcripts.compute_duration, example))
 		data_paths = data_paths if isinstance(data_paths, list) else [data_paths]
 
 		def read_transcript(data_path):
-			transcript_path = data_path + '.json' if '.json' not in data_path else data_path
-			return json.load(maybegzopen(transcript_path)
-								) if any(map(transcript_path.endswith, ['.json', '.json.gz'])) else [dict(audio_path = data_path)]
+			if data_path.endswith('.json.gz') and os.path.exists(data_path):
+				return json.load(gzip.open(data_path, 'rt'))
+			transcript_path = data_path if data_path.endswith('.json') else data_path + '.json'
+			if os.path.exists(transcript_path):
+				return json.load(open(data_path))
+			return [dict(audio_path = data_path)]
 
 		self.examples = [
 			list(g) for data_path in data_paths for k,

--- a/transcribe.py
+++ b/transcribe.py
@@ -262,7 +262,7 @@ if __name__ == '__main__':
 	parser.add_argument('--fp16', choices = ['O0', 'O1', 'O2', 'O3'], default = None)
 	parser.add_argument('--num-workers', type = int, default = 0)
 	parser.add_argument('--mono', action = 'store_true')
-	parser.add_argument('--audio-backend', default = 'ffmpeg', choices = ['sox', 'ffmpeg'])
+	parser.add_argument('--audio-backend', default = None, choices = ['sox', 'ffmpeg'])
 	parser.add_argument('--decoder', default = 'GreedyDecoder', choices = ['GreedyDecoder', 'BeamSearchDecoder'])
 	parser.add_argument('--decoder-topk', type = int, default = 1)
 	parser.add_argument('--beam-width', type = int, default = 5000)


### PR DESCRIPTION
Fix main use-case of transcribe.py, where input folder consists only of wav files, without any meta-info. Previously, transcribe.py would crash in such scenario, due to a bug in read_transcript.